### PR TITLE
Fix/hmr and sprinkle typings

### DIFF
--- a/.changeset/little-spoons-happen.md
+++ b/.changeset/little-spoons-happen.md
@@ -1,0 +1,6 @@
+---
+"@box-extractor/vanilla-extract": patch
+---
+
+fix HMR for SSR after initial load (SSS -> CSR like nextjs) / when using export maps (re-exports in index.ts)
+fix createBoxSprinklesInternal typings (for ReversedConditionsProps) after inlining VE's types (which fixed the .d.ts generated output)

--- a/packages/box-extractor/src/createEsbuildBoxExtractor.ts
+++ b/packages/box-extractor/src/createEsbuildBoxExtractor.ts
@@ -5,10 +5,8 @@ import { Project, ts } from "ts-morph";
 import * as fs from "node:fs";
 import { extract } from "./extractor/extract";
 
-const boxExtractorNamespace = "box-extractor-ns";
-
 export function createEsbuildBoxExtractor({
-    components,
+    components = {},
     functions = {},
     used,
     onExtracted,
@@ -49,15 +47,12 @@ export function createEsbuildBoxExtractor({
                     scriptKind: ts.ScriptKind.TSX,
                 });
 
-                const extracted = extract({ ast: sourceFile!, components, functions, used });
+                const extracted = extract({ ast: sourceFile, components, functions, used });
                 onExtracted?.({ extracted, id: path, isSsr: true, used });
                 // console.dir({ id, extracted }, { depth: null });
 
+                // eslint-disable-next-line unicorn/no-useless-undefined
                 return undefined;
-                // return {
-                //     loader: "tsx",
-                //     contents: code,
-                // };
             });
         },
     };

--- a/packages/box-extractor/src/createViteBoxExtractor.ts
+++ b/packages/box-extractor/src/createViteBoxExtractor.ts
@@ -30,7 +30,7 @@ export type CreateViteBoxExtractorOptions = Pick<ExtractOptions, "components" | 
 } & AllowedExtensionOptions;
 
 export const createViteBoxExtractor = ({
-    components,
+    components = {},
     functions = {},
     used,
     onExtracted,

--- a/packages/box-extractor/src/createViteBoxRefUsageFinder.ts
+++ b/packages/box-extractor/src/createViteBoxRefUsageFinder.ts
@@ -23,8 +23,8 @@ import {
 // TODO logs with debug
 
 export const createViteBoxRefUsageFinder = ({
-    components: _components,
-    functions: _functions,
+    components: _components = {},
+    functions: _functions = {},
     tsConfigFilePath = "tsconfig.json",
     ...options
 }: Omit<CreateViteBoxExtractorOptions, "used" | "onExtracted">): Plugin => {

--- a/packages/box-extractor/src/extractor/extract.ts
+++ b/packages/box-extractor/src/extractor/extract.ts
@@ -24,7 +24,7 @@ export const extract = ({ ast, components: _components, functions: _functions, u
 
     const componentPropValues: ExtractedComponentProperties[] = [];
 
-    Object.entries(components).forEach(([componentName, component]) => {
+    Object.entries(components ?? {}).forEach(([componentName, component]) => {
         const propNameList = component.properties;
         const canTakeAllProp = propNameList === "all";
 

--- a/packages/box-extractor/src/extractor/types.ts
+++ b/packages/box-extractor/src/extractor/types.ts
@@ -19,7 +19,7 @@ export type ExtractedPropMap = Record<string, string | string[]>;
 export type ListOrAll = "all" | string[];
 export type ExtractOptions = {
     ast: SourceFile;
-    components: Record<string, { properties: ListOrAll }> | string[];
+    components?: Record<string, { properties: ListOrAll }> | string[];
     functions?: Record<string, { properties: ListOrAll }> | string[];
     used: UsedComponentsMap;
 };

--- a/packages/vanilla-extract/src/createBoxSprinklesInternal.ts
+++ b/packages/vanilla-extract/src/createBoxSprinklesInternal.ts
@@ -1,11 +1,14 @@
 import { createSprinkles } from "@vanilla-extract/sprinkles";
 import { getSprinklesConfig } from "./getSprinklesConfig";
-import type { SprinklesFn } from "./sprinkle-types";
+import type { SprinklesConditions, SprinklesFn } from "./sprinkle-types";
 import type { SprinklesProperties } from "./types";
 
 export const createBoxSprinklesInternal = <Configs extends readonly SprinklesProperties[]>(
     ...definePropsFn: Configs
-): SprinklesFn<Configs> => {
+): SprinklesFn<Configs> & {
+    conditions: SprinklesConditions<Configs>;
+    shorthands: Map<string, string[]>;
+} => {
     // console.log("createBoxSprinklesInternal");
     const original = createSprinkles(...definePropsFn);
     const config = getSprinklesConfig(definePropsFn);

--- a/packages/vanilla-extract/src/plugins/createEsbuildVanillaExtractSprinklesExtractor.ts
+++ b/packages/vanilla-extract/src/plugins/createEsbuildVanillaExtractSprinklesExtractor.ts
@@ -1,7 +1,6 @@
 import { defaultSerializeVanillaModule } from "@vanilla-extract/integration";
 import { vanillaExtractPlugin } from "@vanilla-extract/esbuild-plugin";
-// import type { VanillaExtractPluginOptions } from "@vanilla-extract/vite-plugin";
-import type { VanillaExtractPluginOptions } from "./ve-vite-plugin";
+import type { VanillaExtractPluginOptions } from "@vanilla-extract/vite-plugin";
 import type { Plugin } from "esbuild";
 
 import { createEsbuildBoxExtractor, UsedComponentsMap } from "@box-extractor/core";
@@ -14,7 +13,7 @@ import {
 import { serializeVanillaModuleWithoutUnused } from "./serializeVanillaModuleWithoutUnused";
 
 export const createEsbuildVanillaExtractSprinklesExtractor = ({
-    components,
+    components = {},
     functions = {},
     onExtracted,
     vanillaExtractOptions,

--- a/packages/vanilla-extract/src/plugins/createViteVanillaExtractSprinklesExtractor.ts
+++ b/packages/vanilla-extract/src/plugins/createViteVanillaExtractSprinklesExtractor.ts
@@ -121,9 +121,7 @@ export const createViteVanillaExtractSprinklesExtractor = ({
 
                 const moduleGraph = server.moduleGraph;
 
-                if (args.isSsr) {
-                    moduleGraph.invalidateAll(); // TODO rm
-                }
+                moduleGraph.invalidateAll();
 
                 if (hasCache) {
                     // const extractDiff = diff(cached!.serialized, serialized);

--- a/packages/vanilla-extract/src/plugins/createViteVanillaExtractSprinklesExtractor.ts
+++ b/packages/vanilla-extract/src/plugins/createViteVanillaExtractSprinklesExtractor.ts
@@ -38,7 +38,7 @@ type OnAfterEvaluateMutation = {
 const logger = debug("box-ex:ve");
 
 export const createViteVanillaExtractSprinklesExtractor = ({
-    components,
+    components = {},
     functions = {},
     onExtracted,
     vanillaExtractOptions,

--- a/packages/vanilla-extract/src/sprinkle-types.ts
+++ b/packages/vanilla-extract/src/sprinkle-types.ts
@@ -2,6 +2,7 @@ import type {
     ConditionalProperty,
     ConditionalPropertyValue,
     ConditionalWithResponsiveArrayProperty,
+    ConditionItem,
     ResponsiveArrayByMaxLength,
     ShorthandProperty,
     SprinklesProperties,
@@ -54,6 +55,10 @@ type SprinkleProps<Args extends readonly any[]> = Args extends [infer L, ...infe
 
 export type SprinklesFn<Args extends readonly SprinklesProperties[]> = ((props: SprinkleProps<Args>) => string) & {
     properties: Set<keyof SprinkleProps<Args>>;
+    /** only defined if using createBoxSprinkles */
+    conditions?: readonly ConditionItem[];
+    /** only defined if using createBoxSprinkles */
+    shorthands?: Map<string, string[]>;
 };
 // end of code taken from vanilla-extract
 


### PR DESCRIPTION
fix HMR for SSR after initial load (SSS -> CSR like nextjs) / when using export maps (re-exports in index.ts)
fix createBoxSprinklesInternal typings (for ReversedConditionsProps) after inlining VE's types (which fixed the .d.ts generated output)