### PR TITLE
WIP: vanilla-extract/recipes purge

### DIFF
--- a/.changeset/soft-ducks-divide.md
+++ b/.changeset/soft-ducks-divide.md
@@ -1,0 +1,5 @@
+---
+"@box-extractor/vanilla-extract": patch
+---
+
+al rm onAfterEvaluateMutation callback

--- a/.changeset/tender-radios-return.md
+++ b/.changeset/tender-radios-return.md
@@ -1,0 +1,7 @@
+---
+"@box-extractor/vanilla-extract": patch
+"@box-extractor/core": patch
+---
+
+build: add tsconfig.compilerOptions.declarationMap
+so we can jump to source with cmd+click

--- a/.eslintrc.build.js
+++ b/.eslintrc.build.js
@@ -18,5 +18,6 @@ module.exports = defineConfig({
         "sonarjs/cognitive-complexity": ["warn", 120],
         "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
         "@typescript-eslint/prefer-string-starts-ends-with": "off",
+        "sonarjs/prefer-single-boolean-return": "warn",
     },
 });

--- a/examples/react-basic/package.json
+++ b/examples/react-basic/package.json
@@ -22,6 +22,7 @@
         "@box-extractor/vanilla-theme": "workspace:*",
         "@dessert-box/react": "^0.4.0",
         "@vanilla-extract/css": "^1.9.2",
+        "@vanilla-extract/recipes": "^0.3.0",
         "@vanilla-extract/sprinkles": "^1.5.0",
         "pastable": "^2.0.10",
         "react": "^18.2.0",

--- a/examples/react-basic/src/App.tsx
+++ b/examples/react-basic/src/App.tsx
@@ -2,7 +2,8 @@ import "./App.css";
 // import { VanillaThemeDemo } from "./components/VanillaThemeDemo";
 // import { Demo } from "./components/Demo";
 // import { MinimalSprinklesDemo } from "./components/MinimalSprinklesDemo";
-import { BoxDemo } from "./components/BoxDemo";
+import { WithRecipe } from "./components/WithRecipe";
+// import { BoxDemo } from "./components/BoxDemo";
 
 function App() {
     return (
@@ -13,7 +14,8 @@ function App() {
                         {/* <Demo /> */}
                         {/* <MinimalSprinklesDemo /> */}
                         {/* <VanillaThemeDemo /> */}
-                        <BoxDemo />
+                        {/* <BoxDemo /> */}
+                        <WithRecipe />
                     </div>
                 </div>
             </div>

--- a/examples/react-basic/src/components/WithRecipe.tsx
+++ b/examples/react-basic/src/components/WithRecipe.tsx
@@ -1,6 +1,10 @@
-import { button } from "./button.recipe.css";
+import { button, multiple, row } from "./button.recipe.css";
 
 // taken from https://vanilla-extract.style/documentation/packages/recipes/#recipe
 export const WithRecipe = () => (
-    <button className={button({ color: "accent", size: "large", rounded: true })}>Hello world</button>
+    <div>
+        <button className={button({ color: "accent", size: "large", rounded: true })}>Hello world</button>
+        <div className={multiple({ first: "colored" })} />
+        <div className={row()} />
+    </div>
 );

--- a/examples/react-basic/src/components/WithRecipe.tsx
+++ b/examples/react-basic/src/components/WithRecipe.tsx
@@ -1,0 +1,6 @@
+import { button } from "./button.recipe.css";
+
+// taken from https://vanilla-extract.style/documentation/packages/recipes/#recipe
+export const WithRecipe = () => (
+    <button className={button({ color: "accent", size: "large", rounded: true })}>Hello world</button>
+);

--- a/examples/react-basic/src/components/button.recipe.css.ts
+++ b/examples/react-basic/src/components/button.recipe.css.ts
@@ -1,11 +1,11 @@
 import { recipe } from "@vanilla-extract/recipes";
+import { minimalSprinkles } from "./minimalSprinkles.css";
 
 // taken from https://vanilla-extract.style/documentation/packages/recipes/#recipe
 export const button = recipe({
     base: {
         borderRadius: 6,
     },
-
     variants: {
         color: {
             neutral: { background: "whitesmoke" },
@@ -21,7 +21,6 @@ export const button = recipe({
             true: { borderRadius: 999 },
         },
     },
-
     // Applied when multiple variants are set at once
     compoundVariants: [
         {
@@ -34,9 +33,20 @@ export const button = recipe({
             },
         },
     ],
-
     defaultVariants: {
         color: "accent",
         size: "medium",
     },
+});
+
+export const multiple = recipe({
+    base: [minimalSprinkles({ color: "brand" }), minimalSprinkles({ backgroundColor: "main" })],
+    variants: {
+        first: { colored: minimalSprinkles({ color: "other" }), absolute: minimalSprinkles({ position: "absolute" }) },
+        second: { backgroundColor: minimalSprinkles({ backgroundColor: "secondary" }) },
+    },
+});
+
+export const row = recipe({
+    base: minimalSprinkles({ display: "flex" }),
 });

--- a/examples/react-basic/src/components/button.recipe.css.ts
+++ b/examples/react-basic/src/components/button.recipe.css.ts
@@ -1,0 +1,42 @@
+import { recipe } from "@vanilla-extract/recipes";
+
+// taken from https://vanilla-extract.style/documentation/packages/recipes/#recipe
+export const button = recipe({
+    base: {
+        borderRadius: 6,
+    },
+
+    variants: {
+        color: {
+            neutral: { background: "whitesmoke" },
+            brand: { background: "blueviolet" },
+            accent: { background: "slateblue" },
+        },
+        size: {
+            small: { padding: 12 },
+            medium: { padding: 16 },
+            large: { padding: 24 },
+        },
+        rounded: {
+            true: { borderRadius: 999 },
+        },
+    },
+
+    // Applied when multiple variants are set at once
+    compoundVariants: [
+        {
+            variants: {
+                color: "neutral",
+                size: "large",
+            },
+            style: {
+                background: "ghostwhite",
+            },
+        },
+    ],
+
+    defaultVariants: {
+        color: "accent",
+        size: "medium",
+    },
+});

--- a/examples/react-basic/src/components/minimalSprinkles.css.ts
+++ b/examples/react-basic/src/components/minimalSprinkles.css.ts
@@ -1,5 +1,5 @@
-import { defineProperties } from "@vanilla-extract/sprinkles";
-import { createBoxSprinkles } from "@box-extractor/vanilla-extract";
+import { createSprinkles, defineProperties } from "@vanilla-extract/sprinkles";
+// import { createBoxSprinkles } from "@box-extractor/vanilla-extract";
 
 const base = defineProperties({
     conditions: {
@@ -27,5 +27,5 @@ const base = defineProperties({
     },
 });
 
-export const minimalSprinkles = createBoxSprinkles(base);
+export const minimalSprinkles = createSprinkles(base);
 export type MinimalSprinkles = Parameters<typeof minimalSprinkles>[0];

--- a/examples/react-basic/src/components/minimalSprinkles.css.ts
+++ b/examples/react-basic/src/components/minimalSprinkles.css.ts
@@ -1,4 +1,5 @@
-import { createSprinkles, defineProperties } from "@vanilla-extract/sprinkles";
+import { defineProperties } from "@vanilla-extract/sprinkles";
+import { createBoxSprinkles } from "@box-extractor/vanilla-extract";
 
 const base = defineProperties({
     conditions: {
@@ -26,5 +27,5 @@ const base = defineProperties({
     },
 });
 
-export const minimalSprinkles = createSprinkles(base);
+export const minimalSprinkles = createBoxSprinkles(base);
 export type MinimalSprinkles = Parameters<typeof minimalSprinkles>[0];

--- a/examples/react-basic/vite.config.ts
+++ b/examples/react-basic/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig((_env) => ({
         createViteVanillaExtractSprinklesExtractor({
             components: ["ColorBox", "DessertBox", "Box"],
             sprinkles: ["colorSprinkles", "themeSprinkles", "minimalSprinkles"],
-            recipes: ["button"],
+            recipes: ["button", "multiple", "row"],
         }),
         // vanillaExtractPlugin() as any,
         react(),

--- a/examples/react-basic/vite.config.ts
+++ b/examples/react-basic/vite.config.ts
@@ -11,10 +11,8 @@ export default defineConfig((_env) => ({
     plugins: [
         createViteVanillaExtractSprinklesExtractor({
             components: ["ColorBox", "DessertBox", "Box"],
-            functions: ["colorSprinkles", "themeSprinkles", "minimalSprinkles"],
-            // vanillaExtractOptions: {
-            //     onAfterEvaluateMutation: (args) => console.dir(args.usedComponents.get("Box"), { depth: null }),
-            // },
+            sprinkles: ["colorSprinkles", "themeSprinkles", "minimalSprinkles"],
+            recipes: ["button"],
         }),
         // vanillaExtractPlugin() as any,
         react(),

--- a/packages/box-extractor/src/createEsbuildBoxExtractor.ts
+++ b/packages/box-extractor/src/createEsbuildBoxExtractor.ts
@@ -38,7 +38,6 @@ export function createEsbuildBoxExtractor({
 
             // build.onLoad({ filter: /.*/, namespace: boxExtractorNamespace }, async ({ path }) => {
             build.onLoad({ filter: tsRE }, async ({ path }) => {
-                console.log({ path });
                 const code = await fs.promises.readFile(path, "utf8");
 
                 // add ts file to project so that references can be resolved

--- a/packages/box-extractor/src/extractor/extract.ts
+++ b/packages/box-extractor/src/extractor/extract.ts
@@ -7,17 +7,17 @@ import { extractCallExpressionValues } from "./extractCallExpressionIdentifierVa
 import { extractJsxAttributeIdentifierValue } from "./extractJsxAttributeIdentifierValue";
 import { extractJsxSpreadAttributeValues } from "./extractJsxSpreadAttributeValues";
 import { castObjectLikeAsMapValue, BoxNode, MapTypeValue } from "./type-factory";
-import type { ExtractOptions, ListOrAll, BoxNodesMap, PropNodesMap } from "./types";
+import type { ExtractOptions, ListOrAll, BoxNodesMap, PropNodesMap, ExtractableMap } from "./types";
 import { isNotNullish } from "./utils";
 
 const logger = createLogger("box-ex:extractor:extract");
 
 export const extract = ({ ast, components: _components, functions: _functions, extractMap }: ExtractOptions) => {
     const components = Array.isArray(_components)
-        ? Object.fromEntries(_components.map((name) => [name, { properties: "all" }]))
+        ? (Object.fromEntries(_components.map((name) => [name, { properties: "all" }])) as ExtractableMap)
         : _components;
     const functions = Array.isArray(_functions)
-        ? Object.fromEntries(_functions.map((name) => [name, { properties: "all" }]))
+        ? (Object.fromEntries(_functions.map((name) => [name, { properties: "all" }])) as ExtractableMap)
         : _functions;
 
     // contains all the extracted nodes from this ast

--- a/packages/box-extractor/src/extractor/findAllTransitiveComponents.ts
+++ b/packages/box-extractor/src/extractor/findAllTransitiveComponents.ts
@@ -321,23 +321,6 @@ const unquote = (str: string) => {
     return str;
 };
 
-/**
- * @see adapted from https://github.com/noahbuscher/react-tsdoc/blob/6231f6be0caf43bcafc32ded14f13f18fbcb54a1/src/utils/reactComponentHelper.ts#L14
- */
-const isReactComponentDefinition = (node: Node): boolean => {
-    if (Node.isVariableDeclaration(node) || Node.isFunctionDeclaration(node)) {
-        const name = node.getName();
-        if (!name) return false;
-
-        const first = name[0];
-        if (!first) return false;
-
-        return first === first.toUpperCase();
-    }
-
-    return false;
-};
-
 const isJsxNamedComponent = (node: Node): node is JsxOpeningElement | JsxSelfClosingElement => {
     return Node.isJsxOpeningElement(node) || Node.isJsxSelfClosingElement(node);
 };

--- a/packages/box-extractor/src/extractor/type-factory.ts
+++ b/packages/box-extractor/src/extractor/type-factory.ts
@@ -5,17 +5,16 @@ import type { ExtractedPropMap, PrimitiveType } from "./types";
 import { isNotNullish } from "./utils";
 
 const BoxKind = Symbol("BoxNode");
-type WithBoxSymbol = { [BoxKind]: true };
+type WithBoxSymbol = { [BoxKind]: true; getNode: () => MaybeNode };
 
 export type MaybeNode = Node | Node[];
-type WithNode = { getNode: () => MaybeNode };
 
-export type ObjectType = WithBoxSymbol & WithNode & { type: "object"; value: ExtractedPropMap; isEmpty?: boolean };
-export type LiteralType = WithBoxSymbol & WithNode & { type: "literal"; value: PrimitiveType | PrimitiveType[] };
-export type MapType = WithBoxSymbol & WithNode & { type: "map"; value: MapTypeValue };
-export type ListType = WithBoxSymbol & WithNode & { type: "list"; value: BoxNode[] };
+export type ObjectType = WithBoxSymbol & { type: "object"; value: ExtractedPropMap; isEmpty?: boolean };
+export type LiteralType = WithBoxSymbol & { type: "literal"; value: PrimitiveType | PrimitiveType[] };
+export type MapType = WithBoxSymbol & { type: "map"; value: MapTypeValue };
+export type ListType = WithBoxSymbol & { type: "list"; value: BoxNode[] };
 export type UnresolvableType = WithBoxSymbol & { type: "unresolvable" };
-export type ConditionalType = WithBoxSymbol & WithNode & { type: "conditional"; whenTrue: BoxNode; whenFalse: BoxNode };
+export type ConditionalType = WithBoxSymbol & { type: "conditional"; whenTrue: BoxNode; whenFalse: BoxNode };
 
 // export type PrimitiveBoxNode = ObjectType | LiteralType | MapType
 export type BoxNode = ObjectType | LiteralType | MapType | ListType | UnresolvableType | ConditionalType;
@@ -152,7 +151,7 @@ export const mergeLiteralTypes = (types: BoxNode[]): BoxNode[] => {
 
     const literal = box.literal(
         Array.from(literalValues),
-        types.flatMap((b) => (b as LiteralType).getNode?.()).filter(isNotNullish)
+        types.flatMap((b) => (b as LiteralType).getNode()).filter(isNotNullish)
     );
     // console.dir({ literal, others }, { depth: null });
     return others.concat(literal);
@@ -167,7 +166,7 @@ export const castObjectLikeAsMapValue = (maybeObject: MaybeObjectLikeBoxReturn, 
     // console.dir({ entries }, { depth: null });
     return new Map<string, BoxNode[]>(
         Object.entries(maybeObject.value).map(([key, value]) => {
-            const boxed = box.cast(value, maybeObject.getNode?.() ?? node);
+            const boxed = box.cast(value, maybeObject.getNode() ?? node);
             if (!boxed) return [key, []];
             return [key, [boxed]];
         })

--- a/packages/box-extractor/src/extractor/types.ts
+++ b/packages/box-extractor/src/extractor/types.ts
@@ -9,13 +9,17 @@ import type { BoxNode, LiteralValue } from "./type-factory";
 export type PrimitiveType = string | number;
 export type ExtractedPropMap = Record<string, LiteralValue>;
 
-export type PropNodesMap = { kind: "component" | "function"; nodesByProp: Map<string, BoxNode[]> };
+export type BoxNodeMapKind = "component" | "function";
+export type PropNodesMap = { kind: BoxNodeMapKind; nodesByProp: Map<string, BoxNode[]> };
 export type BoxNodesMap = Map<string, PropNodesMap>;
 
 export type ListOrAll = "all" | string[];
 export type ExtractOptions = {
     ast: SourceFile;
-    components?: Record<string, { properties: ListOrAll }> | string[];
-    functions?: Record<string, { properties: ListOrAll }> | string[];
+    components?: Extractable;
+    functions?: Extractable;
     extractMap: BoxNodesMap;
 };
+
+export type ExtractableMap = Record<string, { properties: ListOrAll }>;
+export type Extractable = ExtractableMap | string[];

--- a/packages/box-extractor/src/index.ts
+++ b/packages/box-extractor/src/index.ts
@@ -12,9 +12,8 @@ export type {
     LiteralValue,
     MapType,
     MapTypeValue,
-    NodeObjectLiteralExpressionType,
     ObjectType,
     SingleLiteralValue,
 } from "./extractor/type-factory";
 export { isPrimitiveType } from "./extractor/type-factory";
-export type { BoxNodesMap, ExtractOptions, PrimitiveType, PropNodesMap } from "./extractor/types";
+export type { BoxNodesMap, Extractable, ExtractOptions, PrimitiveType, PropNodesMap } from "./extractor/types";

--- a/packages/box-extractor/tsconfig.json
+++ b/packages/box-extractor/tsconfig.json
@@ -7,6 +7,8 @@
         "types": ["vite/client"],
         "noImplicitReturns": false,
         "target": "ES2019",
-        "moduleResolution": "Node"
+        "moduleResolution": "Node",
+        "declaration": true,
+        "declarationMap": true
     }
 }

--- a/packages/vanilla-extract/src/integration.ts
+++ b/packages/vanilla-extract/src/integration.ts
@@ -1,7 +1,7 @@
 export {
     cloneAdapterContext,
-    getCompiledSprinklePropertyByDebugIdPairMap,
-    getUsedClassNameFromCompiledSprinkles,
+    getEvalCompiledResultByKind,
+    getUsedClassNameListFromCompiledResult,
     mutateContextByKeepingUsedRulesOnly,
 } from "./plugins/onEvaluated";
 export { serializeVanillaModuleWithoutUnused } from "./plugins/serializeVanillaModuleWithoutUnused";

--- a/packages/vanilla-extract/src/plugins/createEsbuildVanillaExtractSprinklesExtractor.ts
+++ b/packages/vanilla-extract/src/plugins/createEsbuildVanillaExtractSprinklesExtractor.ts
@@ -10,8 +10,8 @@ import {
 } from "./getUsedPropertiesFromExtractNodeMap";
 import type { CreateViteVanillaExtractSprinklesExtractorOptions } from "./createViteVanillaExtractSprinklesExtractor";
 import {
-    getCompiledSprinklePropertyByDebugIdPairMap,
-    getUsedClassNameFromCompiledSprinkles,
+    getEvalCompiledResultByKind,
+    getUsedClassNameListFromCompiledResult,
     mutateContextByKeepingUsedRulesOnly,
 } from "./onEvaluated";
 import { serializeVanillaModuleWithoutUnused } from "./serializeVanillaModuleWithoutUnused";
@@ -28,7 +28,7 @@ export const createEsbuildVanillaExtractSprinklesExtractor = ({
     vanillaExtractOptions?: VanillaExtractPluginOptions;
 }): Plugin[] => {
     // can probably delete those cache maps
-    const compiledByFilePath = new Map<string, ReturnType<typeof getCompiledSprinklePropertyByDebugIdPairMap>>();
+    const compiledByFilePath = new Map<string, ReturnType<typeof getEvalCompiledResultByKind>>();
     const sourceByPath = new Map<string, string>();
     const usedDebugIdList = new Set<string>();
 

--- a/packages/vanilla-extract/src/plugins/createEsbuildVanillaExtractSprinklesExtractor.ts
+++ b/packages/vanilla-extract/src/plugins/createEsbuildVanillaExtractSprinklesExtractor.ts
@@ -3,7 +3,7 @@ import { defaultSerializeVanillaModule } from "@vanilla-extract/integration";
 import type { VanillaExtractPluginOptions } from "@vanilla-extract/vite-plugin";
 import type { Plugin } from "esbuild";
 
-import { createEsbuildBoxExtractor } from "@box-extractor/core";
+import { createEsbuildBoxExtractor, Extractable } from "@box-extractor/core";
 import {
     getUsedPropertiesFromExtractNodeMap,
     mergeExtractResultInUsedMap,

--- a/packages/vanilla-extract/src/plugins/createEsbuildVanillaExtractSprinklesExtractor.ts
+++ b/packages/vanilla-extract/src/plugins/createEsbuildVanillaExtractSprinklesExtractor.ts
@@ -36,7 +36,9 @@ export const createEsbuildVanillaExtractSprinklesExtractor = ({
 
     const usedDebugIdList = new Set<string>();
     const usedSprinkleDebugIdList = new Set<string>();
+
     const usedRecipeDebugIdList = new Set<string>();
+    const usedRecipeClassNameListByPath = new Map<string, Set<string>>();
 
     const sprinkles: Extractable = Array.isArray(_sprinkles)
         ? Object.fromEntries(_sprinkles.map((name) => [name, { properties: "all" }]))
@@ -75,11 +77,14 @@ export const createEsbuildVanillaExtractSprinklesExtractor = ({
                 }
 
                 // console.dir({ serializeVanillaModule: true, filePath }, { depth: null });
+                const usedRecipeClassNameList = usedRecipeClassNameListByPath.get(filePath) ?? new Set();
+
                 return serializeVanillaModuleWithoutUnused({
                     cssImports,
                     exports,
                     context,
                     usedComponentsMap: usedMap,
+                    usedRecipeClassNameList,
                     compiled,
                 });
             },
@@ -100,11 +105,12 @@ export const createEsbuildVanillaExtractSprinklesExtractor = ({
 
                 compiledByFilePath.set(filePath, compiled);
 
-                const usedClassNameList = getUsedClassNameListFromCompiledResult({
+                const { usedClassNameList, usedRecipeClassNameList } = getUsedClassNameListFromCompiledResult({
                     compiled,
                     usedMap,
                     usedRecipeDebugIdList,
                 });
+                usedRecipeClassNameListByPath.set(filePath, usedRecipeClassNameList);
 
                 // console.log({
                 //     filePath,

--- a/packages/vanilla-extract/src/plugins/createViteVanillaExtractSprinklesExtractor.ts
+++ b/packages/vanilla-extract/src/plugins/createViteVanillaExtractSprinklesExtractor.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { AdapterContext, defaultSerializeVanillaModule, hash, parseFileScope } from "@vanilla-extract/integration";
+import { defaultSerializeVanillaModule, hash, parseFileScope } from "@vanilla-extract/integration";
 
 import { vanillaExtractPlugin, VanillaExtractPluginOptions } from "@vanilla-extract/vite-plugin";
 
@@ -12,6 +12,7 @@ import {
     CreateViteBoxExtractorOptions,
     createViteBoxRefUsageFinder,
     ensureAbsolute,
+    Extractable,
 } from "@box-extractor/core";
 import {
     getUsedPropertiesFromExtractNodeMap,

--- a/packages/vanilla-extract/src/plugins/createViteVanillaExtractSprinklesExtractor.ts
+++ b/packages/vanilla-extract/src/plugins/createViteVanillaExtractSprinklesExtractor.ts
@@ -19,8 +19,8 @@ import {
     UsedComponentMap,
 } from "./getUsedPropertiesFromExtractNodeMap";
 import {
-    getCompiledSprinklePropertyByDebugIdPairMap,
-    getUsedClassNameFromCompiledSprinkles,
+    getEvalCompiledResultByKind,
+    getUsedClassNameListFromCompiledResult,
     mutateContextByKeepingUsedRulesOnly,
 } from "./onEvaluated";
 import { serializeVanillaModuleWithoutUnused } from "./serializeVanillaModuleWithoutUnused";
@@ -61,7 +61,7 @@ export const createViteVanillaExtractSprinklesExtractor = ({
     const getAbsoluteFileId = (source: string) => normalizePath(path.join(config?.root ?? "", source));
 
     const extractCacheById = new Map<string, { hashed: string; serialized: string[] }>();
-    const compiledByFilePath = new Map<string, ReturnType<typeof getCompiledSprinklePropertyByDebugIdPairMap>>();
+    const compiledByFilePath = new Map<string, ReturnType<typeof getEvalCompiledResultByKind>>();
     const usedDebugIdList = new Set<string>();
     const sourceByPath = new Map<string, string>();
     const wasInvalidatedButDidntChange = new Set<string>();
@@ -214,10 +214,7 @@ export const createViteVanillaExtractSprinklesExtractor = ({
 
                 sourceByPath.set(filePath, source);
 
-                const compiled =
-                    compiledByFilePath.get(filePath) ?? getCompiledSprinklePropertyByDebugIdPairMap(evalResult);
-                if (compiled.sprinkleConfigs.size === 0) {
-                    loggerEval("no sprinkles found", { filePath });
+                const compiled = compiledByFilePath.get(filePath) ?? getEvalCompiledResultByKind(evalResult);
                     return;
                 }
 

--- a/packages/vanilla-extract/src/plugins/getUsedPropertiesFromExtractNodeMap.ts
+++ b/packages/vanilla-extract/src/plugins/getUsedPropertiesFromExtractNodeMap.ts
@@ -1,17 +1,18 @@
-import { BoxNode, isPrimitiveType, BoxNodesMap, PrimitiveType } from "@box-extractor/core";
+import { BoxNode, BoxNodesMap, isPrimitiveType, PrimitiveType } from "@box-extractor/core";
 import { castAsArray } from "pastable";
+import { Node } from "ts-morph";
 
 export type PropertiesMap = Map<string, Set<PrimitiveType>>;
 export type ConditionalPropertiesMap = Map<string, Map<string, Set<PrimitiveType>>>;
 export type UsedComponentMap = Map<
     string,
-    {
-        properties: PropertiesMap;
-        conditionalProperties: ConditionalPropertiesMap;
-    }
+    { properties: PropertiesMap; conditionalProperties: ConditionalPropertiesMap }
 >;
 export const getUsedPropertiesFromExtractNodeMap = (nodeMap: BoxNodesMap, usedComponents: UsedComponentMap) => {
     const usedDebugIdList = new Set<string>();
+    const usedSprinkleDebugIdList = new Set<string>();
+    const usedRecipeDebugIdList = new Set<string>();
+    console.log({ getUsedPropertiesFromExtractNodeMap: true, nodeMap, usedComponents });
 
     nodeMap.forEach((boxEl, name) => {
         const currentElement = usedComponents.get(name);
@@ -24,12 +25,18 @@ export const getUsedPropertiesFromExtractNodeMap = (nodeMap: BoxNodesMap, usedCo
             const propertiesListAtCondition =
                 conditionalProperties.get(attrName) ?? new Map<string, Set<PrimitiveType>>();
 
-            const visitNode = (visited: BoxNode) => {
+            const visitNode = (visited: BoxNode, isFromRecipe: boolean) => {
                 if (visited.type === "literal") {
                     const values = castAsArray(visited.value);
                     values.forEach((value) => {
-                        usedDebugIdList.add(`${name}_${attrName}_${value}`);
-                        propertiesList.add(value);
+                        if (!isFromRecipe) {
+                            usedDebugIdList.add(`${name}_${attrName}_${value}`);
+                            usedSprinkleDebugIdList.add(`${name}_${attrName}_${value}`);
+                            propertiesList.add(value);
+                        } else {
+                            usedDebugIdList.add(`recipe.${name}.variant.${attrName}_${value}`);
+                            usedRecipeDebugIdList.add(`recipe.${name}.variant.${attrName}_${value}`);
+                        }
                     });
                 }
 
@@ -37,16 +44,26 @@ export const getUsedPropertiesFromExtractNodeMap = (nodeMap: BoxNodesMap, usedCo
                     visited.value.forEach((propNodes, propName) => {
                         propNodes.forEach((innerNode) => {
                             if (innerNode.type === "literal" && isPrimitiveType(innerNode.value)) {
-                                const actualPropName = attrName.startsWith("_") ? propName : attrName;
-                                const conditionName = attrName.startsWith("_") ? attrName : propName;
+                                if (!isFromRecipe) {
+                                    const actualPropName = attrName.startsWith("_") ? propName : attrName;
+                                    const conditionName = attrName.startsWith("_") ? attrName : propName;
 
-                                usedDebugIdList.add(`${name}_${actualPropName}_${conditionName}_${innerNode.value}`);
+                                    usedDebugIdList.add(
+                                        `${name}_${actualPropName}_${conditionName}_${innerNode.value}`
+                                    );
+                                    usedSprinkleDebugIdList.add(
+                                        `${name}_${actualPropName}_${conditionName}_${innerNode.value}`
+                                    );
 
-                                const current = propertiesListAtCondition.get(propName);
-                                if (current) {
-                                    current.add(innerNode.value);
+                                    const current = propertiesListAtCondition.get(propName);
+                                    if (current) {
+                                        current.add(innerNode.value);
+                                    } else {
+                                        propertiesListAtCondition.set(propName, new Set([innerNode.value]));
+                                    }
                                 } else {
-                                    propertiesListAtCondition.set(propName, new Set([innerNode.value]));
+                                    usedDebugIdList.add(`recipe.${name}.variant.${attrName}_${innerNode.value}`);
+                                    usedRecipeDebugIdList.add(`recipe.${name}.variant.${attrName}_${innerNode.value}`);
                                 }
                             }
                         });
@@ -56,15 +73,22 @@ export const getUsedPropertiesFromExtractNodeMap = (nodeMap: BoxNodesMap, usedCo
                 if (visited.type === "object") {
                     Object.entries(visited.value).forEach(([propName, literal]) => {
                         if (isPrimitiveType(literal)) {
-                            const actualPropName = attrName.startsWith("_") ? propName : attrName;
-                            const conditionName = attrName.startsWith("_") ? attrName : propName;
+                            if (!isFromRecipe) {
+                                const actualPropName = attrName.startsWith("_") ? propName : attrName;
+                                const conditionName = attrName.startsWith("_") ? attrName : propName;
 
-                            usedDebugIdList.add(`${name}_${actualPropName}_${conditionName}_${literal}`);
-                            const current = propertiesListAtCondition.get(propName);
-                            if (current) {
-                                current.add(literal);
+                                usedDebugIdList.add(`${name}_${actualPropName}_${conditionName}_${literal}`);
+                                usedSprinkleDebugIdList.add(`${name}_${actualPropName}_${conditionName}_${literal}`);
+
+                                const current = propertiesListAtCondition.get(propName);
+                                if (current) {
+                                    current.add(literal);
+                                } else {
+                                    propertiesListAtCondition.set(propName, new Set([literal]));
+                                }
                             } else {
-                                propertiesListAtCondition.set(propName, new Set([literal]));
+                                usedDebugIdList.add(`recipe.${name}.variant.${attrName}_${literal}`);
+                                usedRecipeDebugIdList.add(`recipe.${name}.variant.${attrName}_${literal}`);
                             }
                         }
                     });
@@ -72,11 +96,21 @@ export const getUsedPropertiesFromExtractNodeMap = (nodeMap: BoxNodesMap, usedCo
             };
 
             attrNodes.forEach((attrNode) => {
+                const maybeNode = attrNode.getNode();
+                const node = Array.isArray(maybeNode) ? maybeNode[0] : maybeNode;
+                const isFromRecipe = isVanillaExtractRecipe(name, node);
+
+                if (isFromRecipe) {
+                    usedDebugIdList.add(`recipe.${name}.default`);
+                    usedRecipeDebugIdList.add(`recipe.${name}.default`);
+                }
+
+                // console.log({ node: node?.getText(), kind: node?.getKindName(), isRecipe: isFromRecipe });
                 if (attrNode.type === "conditional") {
-                    visitNode(attrNode.whenTrue);
-                    visitNode(attrNode.whenFalse);
+                    visitNode(attrNode.whenTrue, isFromRecipe);
+                    visitNode(attrNode.whenFalse, isFromRecipe);
                 } else {
-                    visitNode(attrNode);
+                    visitNode(attrNode, isFromRecipe);
                 }
             });
 
@@ -95,18 +129,55 @@ export const getUsedPropertiesFromExtractNodeMap = (nodeMap: BoxNodesMap, usedCo
         }
     });
 
+    console.log({ usedDebugIdList });
+
     return {
         usedComponents,
         usedDebugIdList,
+        usedSprinkleDebugIdList,
+        usedRecipeDebugIdList,
     };
 };
 
-export function mergeExtractResultInUsedMap(
-    extractResult: ReturnType<typeof getUsedPropertiesFromExtractNodeMap>,
-    usedDebugIdList: Set<string>,
-    usedMap: UsedComponentMap
-) {
+const isFunctionWithName = (name: string, node: Node | undefined) => {
+    if (!node) return false;
+    // console.log({ node: node?.getText(), kind: node?.getKindName() });
+
+    if (!Node.isCallExpression(node)) return false;
+    if (!Node.isIdentifier(node.getExpression())) return false;
+
+    return node.getExpression().getText() === name;
+};
+
+const isVanillaExtractRecipe = (identifierName: string, node: Node | undefined): boolean => {
+    if (!node) return false;
+
+    const identifier = node.getParentWhile((n) => !isFunctionWithName(identifierName, n));
+    if (!identifier) return false;
+
+    const declaration = node.getParentWhile((n) => !Node.isVariableDeclaration(n));
+    if (!declaration) return false;
+
+    // console.log({ declaration: declaration.getText(), kind: declaration.getKindName() });
+    return true;
+};
+
+export function mergeExtractResultInUsedMap({
+    extractResult,
+    usedDebugIdList,
+    usedSprinkleDebugIdList,
+    usedRecipeDebugIdList,
+    usedMap,
+}: {
+    extractResult: ReturnType<typeof getUsedPropertiesFromExtractNodeMap>;
+    usedDebugIdList: Set<string>;
+    usedSprinkleDebugIdList: Set<string>;
+    usedRecipeDebugIdList: Set<string>;
+    usedMap: UsedComponentMap;
+}) {
     extractResult.usedDebugIdList.forEach((id) => usedDebugIdList.add(id));
+    extractResult.usedSprinkleDebugIdList.forEach((id) => usedSprinkleDebugIdList.add(id));
+    extractResult.usedRecipeDebugIdList.forEach((id) => usedRecipeDebugIdList.add(id));
     extractResult.usedComponents.forEach((value, key) => {
         const currentEl = usedMap.get(key);
         if (!currentEl) {

--- a/packages/vanilla-extract/src/plugins/serializeVanillaModuleWithoutUnused.ts
+++ b/packages/vanilla-extract/src/plugins/serializeVanillaModuleWithoutUnused.ts
@@ -5,7 +5,7 @@ import { stringify } from "javascript-stringify";
 import { isObject } from "pastable";
 import type { UsedComponentMap } from "./getUsedPropertiesFromExtractNodeMap";
 
-import { getCompiledSprinklePropertyByDebugIdPairMap, isCompiledSprinkle } from "./onEvaluated";
+import { getEvalCompiledResultByKind, isCompiledSprinkle } from "./onEvaluated";
 
 type UsedValuesMap = Map<
     string,
@@ -16,13 +16,19 @@ type UsedValuesMap = Map<
     }
 >;
 
-export function serializeVanillaModuleWithoutUnused(
-    cssImports: string[],
-    exports: Record<string, unknown>,
-    context: AdapterContext,
-    usedComponentsMap: UsedComponentMap,
-    compiled: ReturnType<typeof getCompiledSprinklePropertyByDebugIdPairMap>
-) {
+export function serializeVanillaModuleWithoutUnused({
+    cssImports,
+    exports,
+    context,
+    usedComponentsMap,
+    compiled,
+}: {
+    cssImports: string[];
+    exports: Record<string, unknown>;
+    context: AdapterContext;
+    usedComponentsMap: UsedComponentMap;
+    compiled: ReturnType<typeof getEvalCompiledResultByKind>;
+}) {
     // console.log("serializeVanillaModuleWithoutUnused", usedComponentsMap);
     const unusedCompositions = context.composedClassLists
         .filter(({ identifier }) => !context.usedCompositions.has(identifier))
@@ -45,10 +51,7 @@ export function serializeVanillaModuleWithoutUnused(
     return outputCode.join("\n");
 }
 
-function mergeUsedValues(
-    usedMap: UsedComponentMap,
-    compiled: ReturnType<typeof getCompiledSprinklePropertyByDebugIdPairMap>
-) {
+function mergeUsedValues(usedMap: UsedComponentMap, compiled: ReturnType<typeof getEvalCompiledResultByKind>) {
     const mergedMap: UsedValuesMap = new Map();
     const shorthandsMap = new Map(...Array.from(compiled.sprinkleConfigs.values()).map((info) => info.shorthands));
 

--- a/packages/vanilla-extract/tsconfig.json
+++ b/packages/vanilla-extract/tsconfig.json
@@ -7,6 +7,8 @@
         "types": ["vite/client"],
         "noImplicitReturns": false,
         "target": "ES2019",
-        "moduleResolution": "Node"
+        "moduleResolution": "Node",
+        "declaration": true,
+        "declarationMap": true
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ importers:
       '@types/react': ^18.0.15
       '@types/react-dom': ^18.0.6
       '@vanilla-extract/css': ^1.9.2
+      '@vanilla-extract/recipes': ^0.3.0
       '@vanilla-extract/sprinkles': ^1.5.0
       '@vitejs/plugin-react': ^2.0.0
       eslint: ^8.27.0
@@ -63,6 +64,7 @@ importers:
       '@box-extractor/vanilla-theme': link:../../packages/vanilla-theme
       '@dessert-box/react': 0.4.0_react@18.2.0
       '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/recipes': 0.3.0_@vanilla-extract+css@1.9.2
       '@vanilla-extract/sprinkles': 1.5.1_@vanilla-extract+css@1.9.2
       pastable: 2.0.13_react@18.2.0
       react: 18.2.0
@@ -3022,6 +3024,14 @@ packages:
 
   /@vanilla-extract/private/1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
+    dev: false
+
+  /@vanilla-extract/recipes/0.3.0_@vanilla-extract+css@1.9.2:
+    resolution: {integrity: sha512-7wXrgfq1oldKdBfCKen4XmSlDmQR+4o0CQ3WnnLfhQaEtI65xJ774yyQF6dD2CC+hHdW2LFKVXgH5NZRbMQ8Sg==}
+    peerDependencies:
+      '@vanilla-extract/css': ^1.0.0
+    dependencies:
+      '@vanilla-extract/css': 1.9.2
     dev: false
 
   /@vanilla-extract/sprinkles/1.5.1:


### PR DESCRIPTION
# Context:
rm unused styles on recipes as well

# State:
- working fine when using .css.ts files with `@vanilla-extract/recipes` only

- does **NOT** work when using sprinkles in the same file, I mean it does for recipes (un-used variants gets removed) but the whole imported sprinkle will be in the output (instead of just the sprinkle prop+value+conditions combination)..

kinda stuck atm cause of [the same reasons as why we can't remove unused styles directly from .css.ts](https://github.com/astahmer/box-extractor/blob/f0728ca0eb1b3332ce7218584497e9bb2a6f5cdf/README.md#L182-L193)... because VE opts-out of vite context to eval the .css.ts = it gets the content directly from the filesystem, so vite doesn't know about other imported modules

example:
- App.tsx
- button.recipe.css.ts
- sprinkles.css.ts

App.tsx use a recipe from button.recipe.css.ts
button.recipe.css.ts uses sprinkles.css.ts
vite will resolve/load/transform button.recipe.css.ts but not sprinkles.css.ts (which means no extraction as of now, so no removing of unused styles either..)