### PR TITLE
refactor: ExtractOptions -> tag/fn/prop matchers

### DIFF
--- a/.changeset/great-ravens-sparkle.md
+++ b/.changeset/great-ravens-sparkle.md
@@ -1,0 +1,7 @@
+---
+"@box-extractor/core": minor
+---
+
+refactor(core): match tag/fn/prop functions for better control on what gets extracted
+
+opti: forEachDescendant directly on extractable nodes rather than identifier

--- a/README.md
+++ b/README.md
@@ -24,28 +24,8 @@ if you need the static analysis (using [ts-morph](https://github.com/dsherret/ts
 pnpm add @box-extractor/core
 ```
 
-### core/vite
-
-there are 2 plugins from `@box-extractor/core` :
-
--   `createViteBoxExtractor` that will statically analyze your TS(X) files & extract functions args / JSX component props values
--   `createViteBoxRefUsageFinder` will statically analyze your TS(X) files & recursively find every transitive components (the one being spread onto) used from a list of root components
+or you could try it like this:
 
 ```ts
-import { createViteBoxExtractor, createViteBoxRefUsageFinder } from "@box-extractor/core";
+pnpx @box-extractor/cli -i path/to/input.ts -o path/to/report.json --functions="css,styled" --components="div,factory.*,SomeComponent"
 ```
-
-### core/esbuild
-
-only the `createEsbuildBoxExtractor` is made/exported atm from `@box-extractor/core`, it does the same as its vite counterpart
-
-```ts
-import { createEsbuildBoxExtractor } from "@box-extractor/core";
-```
-
-## TODO
-
-some things that are missing:
-
--   tsup/esbuild example (the esbuild plugins are ready today: `createEsbuildBoxExtractor`)
--   [maybe TODO - finder - find all wrapping functions recursively, just like components](https://github.com/astahmer/box-extractor/issues/13)

--- a/packages/box-extractor/src/extractor/extractCallExpressionValues.ts
+++ b/packages/box-extractor/src/extractor/extractCallExpressionValues.ts
@@ -4,12 +4,12 @@ import { maybeBoxNode } from "./maybeBoxNode";
 
 import { maybeObjectLikeBox } from "./maybeObjectLikeBox";
 import { box } from "./type-factory";
-import type { ListOrAll } from "./types";
+import type { MatchFnPropArgs } from "./types";
 import { isNotNullish, unwrapExpression } from "./utils";
 
 const logger = createLogger("box-ex:extractor:call-expr");
 
-export const extractCallExpressionValues = (node: CallExpression, properties: ListOrAll) => {
+export const extractCallExpressionValues = (node: CallExpression, matchProp: (prop: MatchFnPropArgs) => boolean) => {
     const argList = node.getArguments();
     if (argList.length === 0) return box.list([], node, []);
 
@@ -22,18 +22,17 @@ export const extractCallExpressionValues = (node: CallExpression, properties: Li
 
             const maybeValue = maybeBoxNode(argNode, stack);
             logger({ extractCallExpression: true, maybeValue });
-            // !maybeValue && console.log("maybeBoxNode empty", expression.getKindName(), expression.getText());
             if (maybeValue) {
                 return maybeValue;
             }
 
-            const maybeObject = maybeObjectLikeBox(argNode, stack, properties);
+            const maybeObject = maybeObjectLikeBox(argNode, stack, matchProp);
             logger({ maybeObject });
-            // console.log("expr", expression.getKindName(), expression.getText());
             if (maybeObject) return maybeObject;
         })
         .filter(isNotNullish);
 
+    // TODO box.function
     if (boxes.length === 0) return;
     if (boxes.length === 1) return boxes[0]!;
 

--- a/packages/box-extractor/src/extractor/extractFunctionFrom.ts
+++ b/packages/box-extractor/src/extractor/extractFunctionFrom.ts
@@ -38,7 +38,10 @@ export const extractFunctionFrom = <Result>(
     } = {}
 ) => {
     const resultByName = new Map<string, { result: Result; queryBox: BoxNodeList; nameNode: () => BindingName }>();
-    const extractedTheme = extract({ ast: sourceFile, functions: [functionName] });
+    const extractedTheme = extract({
+        ast: sourceFile,
+        functions: { matchFn: ({ fnName }) => fnName === functionName, matchProp: () => true },
+    });
     const fnExtraction = extractedTheme.get(functionName) as ExtractedFunctionResult;
     if (!fnExtraction) return resultByName;
 

--- a/packages/box-extractor/src/extractor/extractJsxAttributeIdentifierValue.ts
+++ b/packages/box-extractor/src/extractor/extractJsxAttributeIdentifierValue.ts
@@ -1,6 +1,6 @@
-import type { Identifier } from "ts-morph";
-import { Node } from "ts-morph";
 import { createLogger } from "@box-extractor/logger";
+import type { JsxAttribute } from "ts-morph";
+import { Node } from "ts-morph";
 
 import { maybeBoxNode } from "./maybeBoxNode";
 import { maybeObjectLikeBox } from "./maybeObjectLikeBox";
@@ -9,18 +9,16 @@ import { unwrapExpression } from "./utils";
 
 const logger = createLogger("box-ex:extractor:jsx-attr");
 
-export const extractJsxAttributeIdentifierValue = (identifier: Identifier) => {
-    // console.log(n.getText(), n.parent.getText());
-    const parent = identifier.getParent();
-    if (!Node.isJsxAttribute(parent)) return;
+// TODO rename file to extractJsxAttribute
+export const extractJsxAttribute = (jsxAttribute: JsxAttribute) => {
     // <ColorBox color="red.200" backgroundColor="blackAlpha.100" />
     //           ^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     // identifier = `color` (and then backgroundColor)
     // parent = `color="red.200"` (and then backgroundColor="blackAlpha.100")
 
-    const initializer = parent.getInitializer();
-    const stack = [parent, initializer] as Node[];
-    if (!initializer) return box.emptyInitializer(identifier, stack);
+    const initializer = jsxAttribute.getInitializer();
+    const stack = [jsxAttribute, initializer] as Node[];
+    if (!initializer) return box.emptyInitializer(jsxAttribute.getNameNode(), stack);
 
     if (Node.isStringLiteral(initializer)) {
         // initializer = `"red.200"` (and then "blackAlpha.100")

--- a/packages/box-extractor/src/extractor/extractJsxSpreadAttributeValues.ts
+++ b/packages/box-extractor/src/extractor/extractJsxSpreadAttributeValues.ts
@@ -1,15 +1,18 @@
-import type { JsxSpreadAttribute, Node } from "ts-morph";
 import { createLogger } from "@box-extractor/logger";
+import type { JsxSpreadAttribute, Node } from "ts-morph";
 
+import { maybeBoxNode } from "./maybeBoxNode";
 import { maybeObjectLikeBox } from "./maybeObjectLikeBox";
 import { box } from "./type-factory";
+import type { MatchFnPropArgs, MatchPropArgs } from "./types";
 import { unwrapExpression } from "./utils";
-import { maybeBoxNode } from "./maybeBoxNode";
-import type { ListOrAll } from "./types";
 
 const logger = createLogger("box-ex:extractor:jsx-spread");
 
-export const extractJsxSpreadAttributeValues = (spreadAttribute: JsxSpreadAttribute, properties: ListOrAll) => {
+export const extractJsxSpreadAttributeValues = (
+    spreadAttribute: JsxSpreadAttribute,
+    matchProp: (prop: MatchFnPropArgs | MatchPropArgs) => boolean
+) => {
     const node = unwrapExpression(spreadAttribute.getExpression());
     logger.scoped("extractJsxSpreadAttributeValues", { node: node.getKindName() });
 
@@ -25,7 +28,7 @@ export const extractJsxSpreadAttributeValues = (spreadAttribute: JsxSpreadAttrib
         }
     }
 
-    const maybeEntries = maybeObjectLikeBox(node, stack, properties);
+    const maybeEntries = maybeObjectLikeBox(node, stack, matchProp);
     logger({ maybeEntries });
     if (maybeEntries) return maybeEntries;
 

--- a/packages/box-extractor/src/extractor/types.ts
+++ b/packages/box-extractor/src/extractor/types.ts
@@ -1,4 +1,12 @@
-import type { CallExpression, JsxOpeningElement, JsxSelfClosingElement, SourceFile } from "ts-morph";
+import type {
+    CallExpression,
+    JsxAttribute,
+    JsxOpeningElement,
+    JsxSelfClosingElement,
+    PropertyAssignment,
+    ShorthandPropertyAssignment,
+    SourceFile,
+} from "ts-morph";
 import type { BoxNode, BoxNodeList, BoxNodeMap, LiteralValue } from "./type-factory";
 
 export type PrimitiveType = string | number | boolean | null | undefined;
@@ -28,12 +36,45 @@ export type ExtractResultItem = ExtractedComponentResult | ExtractedFunctionResu
 export type ExtractResultByName = Map<string, ExtractResultItem>;
 
 export type ListOrAll = "all" | string[];
-export type ExtractOptions = {
-    ast: SourceFile;
-    components?: Extractable;
-    functions?: Extractable;
-    extractMap?: ExtractResultByName;
+
+export type MatchTagArgs = {
+    tagName: string;
+    tagNode: JsxOpeningElement | JsxSelfClosingElement;
+    isFactory: boolean;
+};
+export type MatchPropArgs = {
+    propName: string;
+    propNode: JsxAttribute | undefined;
+};
+export type MatchFnArgs = {
+    fnName: string;
+    fnNode: CallExpression;
+};
+export type MatchFnPropArgs = {
+    propName: string;
+    propNode: PropertyAssignment | ShorthandPropertyAssignment;
+};
+export type MatchPropFn = (prop: MatchPropArgs) => boolean;
+export type FunctionMatchers = {
+    matchFn: (element: MatchFnArgs) => boolean;
+    matchProp: (prop: Pick<MatchFnArgs, "fnName" | "fnNode"> & MatchFnPropArgs) => boolean;
 };
 
-export type ExtractableMap = Record<string, { properties: ListOrAll }>;
-export type Extractable = ExtractableMap | string[];
+export type ComponentMatchers = {
+    matchTag: (element: MatchTagArgs) => boolean;
+    matchProp: (prop: Pick<MatchTagArgs, "tagName" | "tagNode"> & MatchPropArgs) => boolean;
+};
+
+export type ExtractOptions = {
+    ast: SourceFile;
+    components?: ComponentMatchers;
+    functions?: FunctionMatchers;
+    // TODO
+    // evaluateOptions?: EvaluateOptions;
+    // flags?: {
+    //     skipEvaluate?: boolean; // TODO allow list of Node.kind ? = [ts.SyntaxKind.CallExpression, ts.SyntaxKind.ConditionalExpression, ts.SyntaxKind.BinaryExpression]
+    //     skipTraverseFiles?: boolean;
+    //     skipConditions?: boolean;
+    // };
+    extractMap?: ExtractResultByName;
+};

--- a/packages/box-extractor/src/extractor/utils.ts
+++ b/packages/box-extractor/src/extractor/utils.ts
@@ -1,5 +1,4 @@
 import { Node } from "ts-morph";
-import type { Extractable, ExtractableMap } from "./types";
 
 type Nullable<T> = T | null | undefined;
 
@@ -31,12 +30,6 @@ export const unwrapArray = <T>(array: T[]): T | T[] => {
     }
 
     return array;
-};
-
-export const castAsExtractableMap = (extractable: Extractable) => {
-    return Array.isArray(extractable)
-        ? (Object.fromEntries(extractable.map((name) => [name, { properties: "all" }])) as ExtractableMap)
-        : extractable;
 };
 
 export const unquote = (str: string) => {

--- a/packages/box-extractor/src/index.ts
+++ b/packages/box-extractor/src/index.ts
@@ -3,7 +3,7 @@ export { extract, query } from "./extractor/extract";
 export { extractAtRange, extractJsxElementProps } from "./extractor/extractAtRange";
 export { extractCallExpressionValues } from "./extractor/extractCallExpressionValues";
 export { extractFunctionFrom, isImportedFrom } from "./extractor/extractFunctionFrom";
-export { extractJsxAttributeIdentifierValue } from "./extractor/extractJsxAttributeIdentifierValue";
+export { extractJsxAttribute } from "./extractor/extractJsxAttributeIdentifierValue";
 export { extractJsxSpreadAttributeValues } from "./extractor/extractJsxSpreadAttributeValues";
 export type {
     FindAllTransitiveComponentsOptions,
@@ -11,6 +11,7 @@ export type {
     TransitiveMap,
 } from "./extractor/findAllTransitiveComponents";
 export { findAllTransitiveComponents, getAncestorComponent } from "./extractor/findAllTransitiveComponents";
+export { findIdentifierValueDeclaration, getDeclarationFor, isScope } from "./extractor/findIdentifierValueDeclaration";
 export { getBoxLiteralValue } from "./extractor/getBoxLiteralValue";
 export type { MaybeBoxNodeReturn } from "./extractor/maybeBoxNode";
 export { getNameLiteral, maybeBoxNode } from "./extractor/maybeBoxNode";
@@ -39,8 +40,6 @@ export {
     isPrimitiveType,
 } from "./extractor/type-factory";
 export type {
-    Extractable,
-    ExtractableMap,
     ExtractedComponentInstance,
     ExtractedComponentResult,
     ExtractedFunctionInstance,
@@ -51,5 +50,5 @@ export type {
     PrimitiveType,
 } from "./extractor/types";
 export { unbox } from "./extractor/unbox";
-export { castAsExtractableMap, unquote, unwrapExpression } from "./extractor/utils";
+export { unquote, unwrapExpression } from "./extractor/utils";
 export { visitBoxNode } from "./extractor/visitBoxNode";

--- a/packages/box-extractor/tests/createProject.ts
+++ b/packages/box-extractor/tests/createProject.ts
@@ -1,0 +1,47 @@
+import { Project, ts } from "ts-morph";
+import { extract } from "../src/extractor/extract";
+import { ExtractOptions } from "../src/extractor/types";
+
+export const createProject = () => {
+    return new Project({
+        compilerOptions: {
+            jsx: ts.JsxEmit.React,
+            jsxFactory: "React.createElement",
+            jsxFragmentFactory: "React.Fragment",
+            module: ts.ModuleKind.ESNext,
+            target: ts.ScriptTarget.ESNext,
+            noUnusedParameters: false,
+            noEmit: true,
+            useVirtualFileSystem: true,
+            allowJs: true,
+        },
+        skipAddingFilesFromTsConfig: true,
+        skipFileDependencyResolution: true,
+        skipLoadingLibFiles: true,
+    });
+};
+
+export type TestExtractOptions = Omit<ExtractOptions, "ast"> & { tagNameList?: string[]; functionNameList?: string[] };
+export const getTestExtract = (
+    project: Project,
+    code: string,
+    { tagNameList, functionNameList, ...options }: TestExtractOptions
+) => {
+    const sourceFile = project.createSourceFile("file.tsx", code, { overwrite: true, scriptKind: ts.ScriptKind.TSX });
+    return extract({
+        ast: sourceFile,
+        ...options,
+        components: tagNameList
+            ? {
+                  matchTag: ({ tagName }) => tagNameList.includes(tagName),
+                  matchProp: () => true,
+              }
+            : options.components,
+        functions: functionNameList
+            ? {
+                  matchFn: ({ fnName }) => functionNameList.includes(fnName),
+                  matchProp: () => true,
+              }
+            : options.functions,
+    });
+};

--- a/packages/box-extractor/tests/declarations-files.test.ts
+++ b/packages/box-extractor/tests/declarations-files.test.ts
@@ -1,51 +1,13 @@
-import { Project, SourceFile, ts } from "ts-morph";
-import { afterEach, expect, it } from "vitest";
-import { extract } from "../src/extractor/extract";
-import type { ExtractOptions } from "../src/extractor/types";
+import { expect, it } from "vitest";
+import { createProject, getTestExtract, TestExtractOptions } from "./createProject";
 // @ts-ignore
 import { default as ThemeSample } from "./samples/theme?raw";
 
-const createProject = () => {
-    return new Project({
-        compilerOptions: {
-            jsx: ts.JsxEmit.React,
-            jsxFactory: "React.createElement",
-            jsxFragmentFactory: "React.Fragment",
-            module: ts.ModuleKind.ESNext,
-            target: ts.ScriptTarget.ESNext,
-            noUnusedParameters: false,
-            declaration: false,
-            noEmit: true,
-            emitDeclaratio: false,
-            // allowJs: true,
-            // useVirtualFileSystem: true,
-        },
-        // tsConfigFilePath: tsConfigPath,
-        skipAddingFilesFromTsConfig: true,
-        skipFileDependencyResolution: true,
-        skipLoadingLibFiles: true,
-    });
-};
-
-let project: Project = createProject();
-let fileCount = 0;
-
-let sourceFile: SourceFile;
-afterEach(() => {
-    if (!sourceFile) return;
-
-    if (sourceFile.wasForgotten()) return;
-    project.removeSourceFile(sourceFile);
-});
-
-const getExtract = (code: string, options: Omit<ExtractOptions, "ast">) => {
-    const fileName = `file${fileCount++}.tsx`;
-    sourceFile = project.createSourceFile(fileName, code, { scriptKind: ts.ScriptKind.TSX });
-    return extract({ ast: sourceFile, ...options });
-};
+const project = createProject();
+const getExtract = (code: string, options: TestExtractOptions) => getTestExtract(project, code, options);
 
 it("can extract theme with tokens from another package with declaration files", () => {
-    const extracted = getExtract(ThemeSample, { functions: ["defineProperties"] });
+    const extracted = getExtract(ThemeSample, { functionNameList: ["defineProperties"] });
     const defineProperties = extracted.get("defineProperties")!;
 
     expect(defineProperties.nodesByProp).toMatchInlineSnapshot(`

--- a/packages/box-extractor/tests/extract-function-from.test.ts
+++ b/packages/box-extractor/tests/extract-function-from.test.ts
@@ -370,7 +370,7 @@ it("can extract function args when imported from a specific module", () => {
                   },
               },
               queryBox: {
-                  stack: ["CallExpression"],
+                  stack: [],
                   type: "list",
                   node: "CallExpression",
                   value: [

--- a/packages/box-extractor/tests/extractAtRange.test.ts
+++ b/packages/box-extractor/tests/extractAtRange.test.ts
@@ -1,51 +1,11 @@
-import { Project, SourceFile, ts } from "ts-morph";
-import { afterEach, expect, test } from "vitest";
+import { ts } from "ts-morph";
+import { expect, test } from "vitest";
 import { extractAtRange, getTsNodeAtPosition } from "../src/extractor/extractAtRange";
-import type { ExtractOptions } from "../src/extractor/types";
+import { createProject } from "./createProject";
 
-const createProject = () => {
-    return new Project({
-        compilerOptions: {
-            jsx: ts.JsxEmit.React,
-            jsxFactory: "React.createElement",
-            jsxFragmentFactory: "React.Fragment",
-            module: ts.ModuleKind.ESNext,
-            target: ts.ScriptTarget.ESNext,
-            noUnusedParameters: false,
-            declaration: false,
-            noEmit: true,
-            emitDeclaratio: false,
-            // allowJs: true,
-            // useVirtualFileSystem: true,
-        },
-        // tsConfigFilePath: tsConfigPath,
-        skipAddingFilesFromTsConfig: true,
-        skipFileDependencyResolution: true,
-        skipLoadingLibFiles: true,
-    });
-};
-
-let project: Project = createProject();
-let fileCount = 0;
-
-let sourceFile: SourceFile;
-afterEach(() => {
-    if (!sourceFile) return;
-
-    if (sourceFile.wasForgotten()) return;
-    project.removeSourceFile(sourceFile);
-});
-
-const config: ExtractOptions["components"] = {
-    ColorBox: {
-        properties: ["color", "backgroundColor", "zIndex", "fontSize", "display", "mobile", "tablet", "desktop", "css"],
-    },
-};
+const project = createProject();
 const getSourceFile = (code: string) => {
-    const fileName = `file${fileCount++}.tsx`;
-    sourceFile = project.createSourceFile(fileName, code, { scriptKind: ts.ScriptKind.TSX });
-    // return extract({ ast: sourceFile, components: config, ...options });
-    return sourceFile;
+    return project.createSourceFile("file.tsx", code, { overwrite: true, scriptKind: ts.ScriptKind.TSX });
 };
 
 const codeSample = `import Cylinder from "@/cylinder";

--- a/packages/box-extractor/tests/unbox.test.ts
+++ b/packages/box-extractor/tests/unbox.test.ts
@@ -1,53 +1,16 @@
-import { Project, SourceFile, ts } from "ts-morph";
-import { afterEach, expect, test } from "vitest";
-import { extract } from "../src/extractor/extract";
+import { expect, test } from "vitest";
 import { getBoxLiteralValue } from "../src/extractor/getBoxLiteralValue";
+import { ExtractedFunctionResult } from "../src/extractor/types";
 import { unbox } from "../src/extractor/unbox";
-import { ExtractOptions, ExtractedFunctionResult } from "../src/extractor/types";
+import { createProject, getTestExtract, TestExtractOptions } from "./createProject";
 // @ts-ignore
 import { default as BigThemeSampleInlined } from "./samples/BigThemeSampleInlined?raw";
 
-const createProject = () => {
-    return new Project({
-        compilerOptions: {
-            jsx: ts.JsxEmit.React,
-            jsxFactory: "React.createElement",
-            jsxFragmentFactory: "React.Fragment",
-            module: ts.ModuleKind.ESNext,
-            target: ts.ScriptTarget.ESNext,
-            noUnusedParameters: false,
-            declaration: false,
-            noEmit: true,
-            emitDeclaratio: false,
-            // allowJs: true,
-            // useVirtualFileSystem: true,
-        },
-        // tsConfigFilePath: tsConfigPath,
-        skipAddingFilesFromTsConfig: true,
-        skipFileDependencyResolution: true,
-        skipLoadingLibFiles: true,
-    });
-};
-
-const project: Project = createProject();
-
-let sourceFile: SourceFile;
-afterEach(() => {
-    if (!sourceFile) return;
-
-    if (sourceFile.wasForgotten()) return;
-    project.removeSourceFile(sourceFile);
-});
-
-let fileCount = 0;
-const getExtract = (code: string, options: Omit<ExtractOptions, "ast">) => {
-    const fileName = `file${fileCount++}.tsx`;
-    sourceFile = project.createSourceFile(fileName, code, { scriptKind: ts.ScriptKind.TSX });
-    return extract({ ast: sourceFile, ...options });
-};
+const project = createProject();
+const getExtract = (code: string, options: TestExtractOptions) => getTestExtract(project, code, options);
 
 test("unbox", () => {
-    const extracted = getExtract(BigThemeSampleInlined, { functions: ["defineProperties"] });
+    const extracted = getExtract(BigThemeSampleInlined, { functionNameList: ["defineProperties"] });
     const defineProperties = extracted.get("defineProperties")!;
     const properties = (defineProperties as ExtractedFunctionResult).queryList[0].box;
 

--- a/packages/box-extractor/tests/var-usage.test.ts
+++ b/packages/box-extractor/tests/var-usage.test.ts
@@ -1,40 +1,11 @@
-import { Project, SourceFile, ts } from "ts-morph";
-import { afterEach, expect, it } from "vitest";
+import { ts } from "ts-morph";
+import { expect, it } from "vitest";
 import { extractFunctionFrom } from "../src/extractor/extractFunctionFrom";
-import { unbox } from "../src/extractor/unbox";
 import type { BoxNodeLiteral, BoxNodeMap } from "../src/extractor/type-factory";
+import { unbox } from "../src/extractor/unbox";
+import { createProject } from "./createProject";
 
-const createProject = () => {
-    return new Project({
-        compilerOptions: {
-            jsx: ts.JsxEmit.React,
-            jsxFactory: "React.createElement",
-            jsxFragmentFactory: "React.Fragment",
-            module: ts.ModuleKind.ESNext,
-            target: ts.ScriptTarget.ESNext,
-            noUnusedParameters: false,
-            declaration: false,
-            noEmit: true,
-            emitDeclaratio: false,
-            // allowJs: true,
-            // useVirtualFileSystem: true,
-        },
-        // tsConfigFilePath: tsConfigPath,
-        skipAddingFilesFromTsConfig: true,
-        skipFileDependencyResolution: true,
-        skipLoadingLibFiles: true,
-    });
-};
-
-let project: Project = createProject();
-
-let sourceFile: SourceFile;
-afterEach(() => {
-    if (!sourceFile) return;
-
-    if (sourceFile.wasForgotten()) return;
-    project.removeSourceFile(sourceFile);
-});
+const project = createProject();
 
 it("can find usage references from a variable", () => {
     const code = `

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -70,8 +70,8 @@ const main = async () => {
     console.time("extracting");
     const extracted = extract({
         ast: sourceFile,
-        components: args.components.split(",").filter(Boolean),
-        functions: args.functions.split(",").filter(Boolean),
+        components: { matchTag: ({ tagName }) => args.components.split(",").includes(tagName), matchProp: () => true },
+        functions: { matchFn: ({ fnName }) => args.functions.split(",").includes(fnName), matchProp: () => true },
     });
     console.timeEnd("extracting");
     console.log("found:", extracted.size);

--- a/packages/vanilla-wind/src/jit-style-cli.ts
+++ b/packages/vanilla-wind/src/jit-style-cli.ts
@@ -38,7 +38,10 @@ export const main = () => {
     const theme = sources[0]!;
     const usage = sources[1]!;
 
-    const extractedTheme = extract({ ast: theme, functions: ["defineProperties"] });
+    const extractedTheme = extract({
+        ast: theme,
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractedTheme.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     const configByName = new Map<string, { query: ExtractedFunctionInstance; config: GenericConfig }>();
@@ -50,7 +53,10 @@ export const main = () => {
         configByName.set(name, { query, config: getBoxLiteralValue(query.box) as GenericConfig });
     });
 
-    const extractedUsage = extract({ ast: usage, functions: ["tw"] });
+    const extractedUsage = extract({
+        ast: usage,
+        functions: { matchFn: ({ fnName }) => fnName === "tw", matchProp: () => true },
+    });
 
     const ctx = createAdapterContext("debug");
     ctx.setAdapter();

--- a/packages/vanilla-wind/src/vite.ts
+++ b/packages/vanilla-wind/src/vite.ts
@@ -512,7 +512,10 @@ export const vanillaWind = (
                 functionsNameFound.forEach((name) => {
                     logger.scoped("usage", `extracting ${name}() usage...`);
                     // console.time("usage:fn:extract");
-                    const extractResult = extract({ ast: sourceFile, functions: [name] });
+                    const extractResult = extract({
+                        ast: sourceFile,
+                        functions: { matchFn: ({ fnName }) => fnName === name, matchProp: () => true },
+                    });
                     // console.timeEnd("usage:fn:extract");
                     const extracted = extractResult.get(name)! as ExtractedFunctionResult;
                     if (!extracted) {
@@ -540,7 +543,10 @@ export const vanillaWind = (
                     const themeName = component.themeName;
                     logger.scoped("usage", `extracting <${name} /> usage...`);
                     // console.time("usage:component:extract");
-                    const extractResult = extract({ ast: sourceFile, components: [name] });
+                    const extractResult = extract({
+                        ast: sourceFile,
+                        components: { matchTag: ({ tagName }) => tagName === name, matchProp: () => true },
+                    });
                     // console.timeEnd("usage:component:extract");
                     const extracted = extractResult.get(name)! as ExtractedFunctionResult;
                     if (!extracted) {

--- a/packages/vanilla-wind/tests/createTheme.test.ts
+++ b/packages/vanilla-wind/tests/createTheme.test.ts
@@ -1,5 +1,3 @@
-import type { ExtractResultByName, ExtractOptions } from "@box-extractor/core";
-import { extract } from "@box-extractor/core";
 import { Project, SourceFile, ts } from "ts-morph";
 import { afterEach, expect, test } from "vitest";
 import { extractCreateTheme } from "../src/extractCreateTheme";
@@ -29,8 +27,7 @@ const createProject = () => {
     });
 };
 
-let project: Project = createProject();
-let fileCount = 0;
+const project = createProject();
 
 let sourceFile: SourceFile;
 afterEach(() => {
@@ -39,14 +36,6 @@ afterEach(() => {
     if (sourceFile.wasForgotten()) return;
     project.removeSourceFile(sourceFile);
 });
-
-const extractFromCode = (code: string | SourceFile, options: Partial<ExtractOptions>) => {
-    const extractMap = new Map() as ExtractResultByName;
-    const fileName = `file${fileCount++}.tsx`;
-    sourceFile =
-        typeof code === "string" ? project.createSourceFile(fileName, code, { scriptKind: ts.ScriptKind.TSX }) : code;
-    return extract({ ast: sourceFile, extractMap, ...options });
-};
 
 const withImportAndTokens = `
     import { ConfigConditions, createTheme, defineProperties } from "@box-extractor/vanilla-wind";

--- a/packages/vanilla-wind/tests/defineProperties.test.ts
+++ b/packages/vanilla-wind/tests/defineProperties.test.ts
@@ -310,7 +310,7 @@ it("types are fine", () => {
             )
         }
     `,
-            { functions: ["tw"] }
+            { functions: { matchFn: ({ fnName }) => ["tw"].includes(fnName), matchProp: () => true } }
         )
     ).toMatchInlineSnapshot(`
       {
@@ -752,7 +752,7 @@ it("types are fine", () => {
                   {
                       name: "tw",
                       box: {
-                          stack: ["CallExpression"],
+                          stack: [],
                           type: "list",
                           node: "CallExpression",
                           value: [

--- a/packages/vanilla-wind/tests/eval-vs-extract.bench.ts
+++ b/packages/vanilla-wind/tests/eval-vs-extract.bench.ts
@@ -65,7 +65,10 @@ describe("eval-vs-extract", () => {
 
 const extractThemeConfig = (sourceFile: SourceFile) => {
     const configByName = new Map<string, GenericConfig>();
-    const extractedTheme = extract({ ast: sourceFile, functions: ["defineProperties"] });
+    const extractedTheme = extract({
+        ast: sourceFile,
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractedTheme.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     queryList.forEach((query) => {

--- a/packages/vanilla-wind/tests/jit-style.test.ts
+++ b/packages/vanilla-wind/tests/jit-style.test.ts
@@ -92,7 +92,9 @@ it("minimal atomic local class", () => {
     `
     );
 
-    const extractDefs = extractFromCode(sourceFile, { functions: ["defineProperties"] });
+    const extractDefs = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractDefs.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     const configByName = new Map<string, { query: ExtractedFunctionInstance; config: GenericConfig }>();
@@ -109,7 +111,9 @@ it("minimal atomic local class", () => {
     setFileScope("test/jit-style.test.ts");
 
     const fnName = "atomicLocal";
-    const extracted = extractFromCode(sourceFile, { functions: [fnName] });
+    const extracted = extractFromCode(sourceFile, {
+        functions: { matchFn: (fn) => fn.fnName === fnName, matchProp: () => true },
+    });
     const styles = generateStyleFromExtraction({
         name: fnName,
         extracted: extracted.get(fnName)! as ExtractedFunctionResult,
@@ -295,7 +299,9 @@ it("minimal grouped local class", () => {
     `
     );
 
-    const extractDefs = extractFromCode(sourceFile, { functions: ["defineProperties"] });
+    const extractDefs = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractDefs.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     const configByName = new Map<string, { query: ExtractedFunctionInstance; config: GenericConfig }>();
@@ -312,7 +318,9 @@ it("minimal grouped local class", () => {
     setFileScope("test/jit-style.test.ts");
 
     const fnName = "groupedLocal";
-    const extracted = extractFromCode(sourceFile, { functions: [fnName] });
+    const extracted = extractFromCode(sourceFile, {
+        functions: { matchFn: (fn) => fn.fnName === fnName, matchProp: () => true },
+    });
     const styles = generateStyleFromExtraction({
         name: fnName,
         extracted: extracted.get(fnName)! as ExtractedFunctionResult,
@@ -529,7 +537,9 @@ it("minimal global", () => {
     `
     );
 
-    const extractDefs = extractFromCode(sourceFile, { functions: ["defineProperties"] });
+    const extractDefs = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractDefs.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     const configByName = new Map<string, { query: ExtractedFunctionInstance; config: GenericConfig }>();
@@ -546,7 +556,9 @@ it("minimal global", () => {
     setFileScope("test/jit-style.test.ts");
 
     const fnName = "minimalGlobal";
-    const extracted = extractFromCode(sourceFile, { functions: [fnName] });
+    const extracted = extractFromCode(sourceFile, {
+        functions: { matchFn: (fn) => fn.fnName === fnName, matchProp: () => true },
+    });
     const styles = generateStyleFromExtraction({
         name: fnName,
         extracted: extracted.get(fnName)! as ExtractedFunctionResult,
@@ -792,14 +804,16 @@ it("simple CallExpression extract + JIT style + replace call by generated classN
         { scriptKind: ts.ScriptKind.TSX }
     );
 
-    const extractDefs = extractFromCode(sourceFile, { functions: ["defineProperties"] });
+    const extractDefs = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractDefs.get("defineProperties") as ExtractedFunctionResult).queryList;
     expect(queryList).toMatchInlineSnapshot(`
       [
           {
               name: "defineProperties",
               box: {
-                  stack: ["CallExpression"],
+                  stack: [],
                   type: "list",
                   node: "CallExpression",
                   value: [
@@ -858,7 +872,7 @@ it("simple CallExpression extract + JIT style + replace call by generated classN
           {
               name: "defineProperties",
               box: {
-                  stack: ["CallExpression"],
+                  stack: [],
                   type: "list",
                   node: "CallExpression",
                   value: [
@@ -1339,7 +1353,9 @@ it("simple CallExpression extract + JIT style + replace call by generated classN
         configByName.set(name, { query, config: value as GenericConfig });
     });
 
-    const extracted = extractFromCode(sourceFile, { functions: ["minimalSprinkles", "tw"] });
+    const extracted = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => ["minimalSprinkles", "tw"].includes(fnName), matchProp: () => true },
+    });
 
     const ctx = createAdapterContext("debug");
     ctx.setAdapter();
@@ -1351,7 +1367,7 @@ it("simple CallExpression extract + JIT style + replace call by generated classN
           {
               name: "minimalSprinkles",
               box: {
-                  stack: ["CallExpression"],
+                  stack: [],
                   type: "list",
                   node: "CallExpression",
                   value: [
@@ -1375,7 +1391,7 @@ it("simple CallExpression extract + JIT style + replace call by generated classN
           {
               name: "minimalSprinkles",
               box: {
-                  stack: ["CallExpression"],
+                  stack: [],
                   type: "list",
                   node: "CallExpression",
                   value: [
@@ -1456,7 +1472,7 @@ it("simple CallExpression extract + JIT style + replace call by generated classN
           {
               name: "tw",
               box: {
-                  stack: ["CallExpression"],
+                  stack: [],
                   type: "list",
                   node: "CallExpression",
                   value: [
@@ -1728,7 +1744,9 @@ const className = tw({
 it("will generate multiple styles with nested conditions", () => {
     const sourceFile = project.createSourceFile("multiple.css.ts", codeSample);
 
-    const extractDefs = extractFromCode(sourceFile, { functions: ["defineProperties"] });
+    const extractDefs = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractDefs.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     const configByName = new Map<string, { query: ExtractedFunctionInstance; config: GenericConfig }>();
@@ -1744,7 +1762,9 @@ it("will generate multiple styles with nested conditions", () => {
     ctx.setAdapter();
     setFileScope("test/jit-style.test.ts");
 
-    const extracted = extractFromCode(sourceFile, { functions: ["tw"] });
+    const extracted = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => ["tw"].includes(fnName), matchProp: () => true },
+    });
     const tw = extracted.get("tw")! as ExtractedFunctionResult;
     const twStyles = generateStyleFromExtraction({
         name: "tw",
@@ -1755,7 +1775,7 @@ it("will generate multiple styles with nested conditions", () => {
     const magicStr = new MagicString(sourceFile.getFullText());
     const generateStyleResults = new Set<ReturnType<typeof generateStyleFromExtraction>>();
 
-    expect(twStyles.classByDebugId.size).toMatchInlineSnapshot('22');
+    expect(twStyles.classByDebugId.size).toMatchInlineSnapshot("22");
     expect(twStyles.classByDebugId).toMatchInlineSnapshot(`
       {
           "tw_backgroundColor_blue.500": "tw_backgroundColor_blue.500__1rxundp0",
@@ -2314,7 +2334,9 @@ it("will generate multiple styles with nested conditions", () => {
 it("will generate multiple styles with nested conditions - grouped", () => {
     const sourceFile = project.createSourceFile("multiple.grouped.css.ts", codeSample);
 
-    const extractDefs = extractFromCode(sourceFile, { functions: ["defineProperties"] });
+    const extractDefs = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractDefs.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     const configByName = new Map<string, { query: ExtractedFunctionInstance; config: GenericConfig }>();
@@ -2330,7 +2352,9 @@ it("will generate multiple styles with nested conditions - grouped", () => {
     ctx.setAdapter();
     setFileScope("test/jit-style.test.ts");
 
-    const extracted = extractFromCode(sourceFile, { functions: ["tw"] });
+    const extracted = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => ["tw"].includes(fnName), matchProp: () => true },
+    });
     const tw = extracted.get("tw")! as ExtractedFunctionResult;
     const twStyles = generateStyleFromExtraction({
         name: "tw",
@@ -2967,7 +2991,9 @@ it("minimal example with <Box /> component", () => {
     `
     );
 
-    const extractDefs = extractFromCode(sourceFile, { functions: ["defineProperties"] });
+    const extractDefs = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractDefs.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     const configByName = new Map<string, { query: ExtractedFunctionInstance; config: GenericConfig }>();
@@ -2984,7 +3010,9 @@ it("minimal example with <Box /> component", () => {
     setFileScope("test/jit-style.test.ts");
 
     const name = "Box";
-    const extractResult = extractFromCode(sourceFile, { components: [name] });
+    const extractResult = extractFromCode(sourceFile, {
+        components: { matchTag: ({ tagName }) => [name].includes(tagName), matchProp: () => true },
+    });
     const extracted = extractResult.get(name)! as ExtractedComponentResult;
 
     const conf = configByName.get("tw")!;
@@ -3235,7 +3263,9 @@ it("minimal example with global style", () => {
     `
     );
 
-    const extractDefs = extractFromCode(sourceFile, { functions: ["defineProperties"] });
+    const extractDefs = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => fnName === "defineProperties", matchProp: () => true },
+    });
     const queryList = (extractDefs.get("defineProperties") as ExtractedFunctionResult).queryList;
 
     const configByName = new Map<string, { query: ExtractedFunctionInstance; config: GenericConfig }>();
@@ -3252,7 +3282,9 @@ it("minimal example with global style", () => {
     setFileScope("test/jit-style.test.ts");
 
     const name = "css";
-    const extractResult = extractFromCode(sourceFile, { functions: [name] });
+    const extractResult = extractFromCode(sourceFile, {
+        functions: { matchFn: ({ fnName }) => [name].includes(fnName), matchProp: () => true },
+    });
     const extracted = extractResult.get(name)! as ExtractedComponentResult;
 
     const conf = configByName.get("css")!;

--- a/packages/vanilla-wind/tests/str-manipulation.bench.ts
+++ b/packages/vanilla-wind/tests/str-manipulation.bench.ts
@@ -57,14 +57,16 @@ describe("ts-morph remove/replaceWihtText vs magic-string update", () => {
     bench("ts-morph replaceWithText", () => {
         resetSourceFile();
 
-        const extracted = extract({ ast: sourceFile, components: ["Box", "Stack"] });
+        const extracted = extract({
+            ast: sourceFile,
+            components: { matchTag: ({ tagName }) => ["Box", "Stack"].includes(tagName), matchProp: () => true },
+        });
         let count = 0;
 
         extracted.forEach((map) => {
             map.queryList.forEach((query) => {
                 if (query.box.isMap()) {
-                    query.box.value.forEach((nodeList) => {
-                        const boxNode = nodeList[0]!;
+                    query.box.value.forEach((boxNode) => {
                         const jsxAttribute = boxNode.getStack()[0];
                         if (Node.isJsxAttribute(jsxAttribute)) {
                             count++;
@@ -90,14 +92,16 @@ describe("ts-morph remove/replaceWihtText vs magic-string update", () => {
     bench("ts-morph remove", () => {
         resetSourceFile();
 
-        const extracted = extract({ ast: sourceFile, components: ["Box", "Stack"] });
+        const extracted = extract({
+            ast: sourceFile,
+            components: { matchTag: ({ tagName }) => ["Box", "Stack"].includes(tagName), matchProp: () => true },
+        });
         let count = 0;
 
         extracted.forEach((map) => {
             map.queryList.forEach((query) => {
                 if (query.box.isMap()) {
-                    query.box.value.forEach((nodeList) => {
-                        const boxNode = nodeList[0]!;
+                    query.box.value.forEach((boxNode) => {
                         const jsxAttribute = boxNode.getStack()[0];
                         if (Node.isJsxAttribute(jsxAttribute)) {
                             count++;
@@ -131,7 +135,10 @@ describe("ts-morph remove/replaceWihtText vs magic-string update", () => {
     bench("magic-string update", () => {
         resetSourceFile();
 
-        const extracted = extract({ ast: sourceFile, components: ["Box", "Stack"] });
+        const extracted = extract({
+            ast: sourceFile,
+            components: { matchTag: ({ tagName }) => ["Box", "Stack"].includes(tagName), matchProp: () => true },
+        });
         let count = 0;
 
         const original = sourceFile.getFullText();
@@ -140,8 +147,7 @@ describe("ts-morph remove/replaceWihtText vs magic-string update", () => {
         extracted.forEach((map) => {
             map.queryList.forEach((query) => {
                 if (query.box.isMap()) {
-                    query.box.value.forEach((nodeList) => {
-                        const boxNode = nodeList[0]!;
+                    query.box.value.forEach((boxNode) => {
                         const jsxAttribute = boxNode.getStack()[0];
                         if (Node.isJsxAttribute(jsxAttribute)) {
                             count++;

--- a/site/src/Playground/Playground.machine.ts
+++ b/site/src/Playground/Playground.machine.ts
@@ -131,8 +131,8 @@ export const playgroundMachine = createMachine(
                 const result = extract({
                     ast: sourceFile,
                     extractMap: new Map(),
-                    components: ctx.components,
-                    functions: ctx.functions,
+                    components: { matchTag: ({ tagName }) => ctx.components.includes(tagName), matchProp: () => true },
+                    functions: { matchFn: ({ fnName }) => ctx.components.includes(fnName), matchProp: () => true },
                 });
                 // console.log({ value });
                 console.log(result);


### PR DESCRIPTION
feat: expose findIdentifierValueDeclaration, getDeclarationFor, isScope

opti: forEachDescendant directly on extractable nodes rather than identifier